### PR TITLE
fix: Fixes grammar and implementation test mismatch for alignments

### DIFF
--- a/message-template.ebnf
+++ b/message-template.ebnf
@@ -4,4 +4,4 @@ Index::= [0-9]+
 Format ::= [^\}]+
 Template ::= (Text | Hole)*
 Hole ::=  '{' ('@' | '$')? (Name | Index) (',' Alignment)? (':' Format)? '}'
-Alignment ::= '-'?[0-9]+
+Alignment ::= '-'?[1-9][0-9]*


### PR DESCRIPTION
While implementing a message templates parser I pulled the message templates tests from the C# repo to ensure that my parsing behaviour was correct & translated them into rust. While I was doing that I saw that alignment was specified to be able to be any digits preceded by an optional '-' but the test [ZeroValuesAlignmentIsParsedAsText](https://github.com/messagetemplates/messagetemplates-csharp/blob/master/test/MessageTemplates.Tests/ParserTests.cs#L88) indicates that the first digit should not be able to be zero.

This seems to be the intended behaviour & there isn't a consensus across the ecosystem: Your repo + serilog treat it as invalid, though I believe serilog just nabbed most of your tests and [nlog](https://github.com/NLog/NLog/blob/dev/tests/NLog.UnitTests/MessageTemplates/ParserTests.cs#L98) treats it as valid. However given there's a specific test for it I expected that this was an oversight in the grammar definition and figured I could help either fix it here or in the tests.